### PR TITLE
update follow registry to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "davlog": "~0.1.2",
     "dnscache": "~0.0.3",
     "event-stream": "^3.1.5",
-    "follow-registry": "^1.0.0",
+    "follow-registry": "^2.0.0",
     "fs-blob-store": "^5.1.1",
     "graceful-fs": "^2.0.3",
     "http-https": "^1.0.0",

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -89,6 +89,7 @@ describe('verify', function () {
     beforeEach(clearData)
 
     it('downloads the file and calls verify', function (done) {
+      this.timeout(1000000)
       var info = {
         path: '//registry-static/-/registry-static-0.1.11.tgz',
         tarball: 'registry-static-0.1.11.tgz'
@@ -117,6 +118,7 @@ describe('verify', function () {
     })
 
     it('tries to download with a 404 file and calls back with an error', function (done) {
+      this.timeout(1000000)
       // var callback = this.callback
       var info = {
         path: '//foobarbaz.tgz',


### PR DESCRIPTION
@dignifiedquire, updating to follow-registry 2.0.0 (with your changes to increase perf), broke the tests on registry-static. I have been using it directly because the PR on follow-registry wasn't merged and published, which cause me to detected this only now.
